### PR TITLE
Improve Travis-related setup and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   fast_finish: true
   include:
     # Ubuntu 14.04 versions
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4"
            NUMPY_VERSION="1.10" SCIPY_VERSION="0.16"
            SCIKIT_LEARN_VERSION="0.16" MATPLOTLIB_VERSION="1.4"
            NILEARN_VERSION="0.2.0"

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -33,7 +33,7 @@ print_conda_requirements() {
     # if yes which version to install. For example:
     #   - for numpy, NUMPY_VERSION is used
     #   - for scikit-learn, SCIKIT_LEARN_VERSION is used
-    TO_INSTALL_ALWAYS="pip pytest"
+    TO_INSTALL_ALWAYS="pip pytest cython"
     REQUIREMENTS="$TO_INSTALL_ALWAYS"
     TO_INSTALL_MAYBE="python numpy scipy matplotlib scikit-learn flake8"
     for PACKAGE in $TO_INSTALL_MAYBE; do

--- a/modl/dict_fact.py
+++ b/modl/dict_fact.py
@@ -265,7 +265,7 @@ class DictMF(BaseEstimator):
             self._init_arrays(X)
         if check_input:
             X = check_array(X, dtype='float', order='C',
-                            accept_sparse=self.sparse_)
+                            accept_sparse='csr' if self.sparse_ else None)
         return X
 
     def _refit(self, X):

--- a/modl/dict_fact.py
+++ b/modl/dict_fact.py
@@ -183,7 +183,7 @@ class DictMF(BaseEstimator):
 
         self.counter_ = np.zeros(n_cols + 1, dtype='int')
 
-        self.n_iter_ = np.zeros(1, dtype='long')
+        self.n_iter_ = np.zeros(1, dtype='int64')
 
         self.code_ = np.zeros((self.n_samples_, self.n_components))
 


### PR DESCRIPTION
Some minor fixes to make Travis a bit more well-behaved. Still one error in `modl/tests/test_spca_fmri.py` that I leave you deal with:

```
$ pytest modl/tests/test_spca_fmri.py
======================================================== test session starts ========================================================
platform linux -- Python 3.4.5, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/lesteve/dev/modl/modl, inifile: 
collected 3 items 

modl/tests/test_spca_fmri.py F..

============================================================= FAILURES ==============================================================
________________________________________________________ test_sparse_pca[c] _________________________________________________________

backend = 'c'

    @pytest.mark.parametrize("backend", backends)
    def test_sparse_pca(backend):
        data, mask_img, components, rng = _make_test_data(n_subjects=10)
        sparse_pca = SpcaFmri(n_components=4, random_state=0,
                              mask=mask_img,
                              backend=backend,
                              reduction=2,
                              smoothing_fwhm=0., n_epochs=3, alpha=0.01)
        sparse_pca.fit(data)
        maps = sparse_pca.masker_. \
            inverse_transform(sparse_pca.components_).get_data()
        maps = np.reshape(np.rollaxis(maps, 3, 0), (4, 400))
    
        S = np.sqrt(np.sum(components ** 2, axis=1))
        S[S == 0] = 1
        components /= S[:, np.newaxis]
    
        S = np.sqrt(np.sum(maps ** 2, axis=1))
        S[S == 0] = 1
        maps /= S[:, np.newaxis]
    
        G = np.abs(components.dot(maps.T))
        recovered_maps = np.sum(G > 0.95)
>       assert(recovered_maps >= 4)
E       assert 3 >= 4

modl/tests/test_spca_fmri.py:97: AssertionError
================================================ 1 failed, 2 passed in 1.74 seconds =================================================

```