### PR TITLE
Fix for seed value checking, can be int or long

### DIFF
--- a/modl/utils/randomkit/random_fast.pyx
+++ b/modl/utils/randomkit/random_fast.pyx
@@ -68,6 +68,8 @@ cdef class RandomState:
         elif isinstance(seed, np.integer):
             iseed = int(seed)
             rk_seed(iseed, self.internal_state)
+        elif isinstance(seed, (int, long)):
+            rk_seed(seed, self.internal_state)
         else:
             raise ValueError("Wrong seed")
 


### PR DESCRIPTION
Hot fix for ValueError("Wrong seed")
reference:

[https://github.com/arthurmensch/modl/issues/10](https://github.com/arthurmensch/modl/issues/10)